### PR TITLE
Readthedocs integration (Feature/readthedocs compat)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,9 +24,8 @@ sphinx:
 #    - pdf
 #    - epub
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
+# declare the Python requirements required to build the documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-#python:
-#  install:
-#  - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+#python:
+#  install:
+#  - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=6.2.1
+sphinx-autoapi>=3.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # This file lists the Python requirements that are required to build the documentation.
 # It is needed for readthedocs, see the .readthedocs.yaml file in the root directory.
+#
 sphinx>=6.2.1
 sphinx-autoapi>=3.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
+# This file lists the Python requirements that are required to build the documentation.
+# It is needed for readthedocs, see the .readthedocs.yaml file in the root directory.
 sphinx>=6.2.1
 sphinx-autoapi>=3.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 # This file lists the Python requirements that are required to build the documentation.
 # It is needed for readthedocs, see the .readthedocs.yaml file in the root directory.
-#
 sphinx>=6.2.1
 sphinx-autoapi>=3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-depot"
-version = "3.0.5"
+version = "3.1.5"
 description = "Depot Simulation for eFLIPS"
 authors = ["Enrico Lauth <enrico.lauth@tu-berlin.de>",
     "Ludger Heide <ludger.heide@tu-berlin.de",


### PR DESCRIPTION
Created the necessary files for readthedocs to function properly.

We should keep in mind that we now specify the packages needed for the documentation (sphinx and sphinx-autoapi) at two places: in the requirements.txt inside the docs folder (for readthedocs) as well as in the pyproject.toml file (for the eflips-depot package itself). Might be relevant IF we need to update sphinx or sphinx-autoapi version numbers in the future