### PR TITLE
Shrink Areas and electrified termini to peak observed usage

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "eFLIPS-Depot"
 copyright = "2023, MPM TU Berlin"
 author = "MPM TU Berlin"
-release = "4.17.2"
+release = "4.18.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/eflips/depot/api/__init__.py
+++ b/eflips/depot/api/__init__.py
@@ -23,6 +23,8 @@ The following steps are recommended for using the API:
 4. For the results to be valid, the consumption simulation should now be run again.
     a. If you are using an external consumption model, run it again making sure it does not create new vehicles.
     b. Run the :func:`simple_consumption_simulation` function again, this time with ``initialize_vehicles=False``.
+5. Optionally (enabled by default in :func:`simulate_scenario`), call :func:`shrink_to_peak_usage` to right-size
+   the auto-generated depots and electrified opportunity-charging stations to their peak observed concurrency.
 """
 import copy
 import logging
@@ -105,6 +107,10 @@ from eflips.depot.api.private.util import (
 )
 
 from eflips.depot.api.private.depot import AreaInformation, DepotConfigurationWish
+from eflips.depot.api.private.shrink import (
+    _shrink_areas_to_peak,
+    _shrink_stations_to_peak,
+)
 
 
 class SmartChargingStrategy(Enum):
@@ -632,6 +638,44 @@ def apply_even_smart_charging(
                 session.add(event)
 
 
+def shrink_to_peak_usage(
+    scenario: Union[Scenario, int, Any],
+    database_url: Optional[str] = None,
+    resolution: timedelta = timedelta(minutes=5),
+) -> None:
+    """Shrink Areas and electrified terminus Stations to their peak observed usage.
+
+    A freshly generated depot layout is intentionally over-provisioned, but
+    downstream cost estimation counts every slot. This pass walks every
+    :class:`eflips.model.Area` in the scenario and reduces ``Area.capacity`` to
+    the maximum number of simultaneous events observed at that area (rounded up
+    to the next valid value for the area type). Areas that saw no events at all
+    are deleted. Each :class:`eflips.model.Station` with ``is_electrified=True``
+    and ``charge_type=ChargeType.OPPORTUNITY`` has its
+    ``amount_charging_places`` (and ``power_total``) reduced to peak observed
+    CHARGING_OPPORTUNITY concurrency; stations with zero such events are
+    un-electrified.
+
+    Must be called *after* :func:`add_evaluation_to_database` so the events are
+    persisted in the database. :func:`simulate_scenario` calls this
+    automatically by default.
+
+    :param scenario: A :class:`eflips.model.Scenario`, its integer id, or any
+        object with an ``id`` attribute pointing to a scenario id.
+    :param database_url: Optional database URL. Falls back to ``DATABASE_URL``
+        if the scenario is not given as a :class:`Scenario` object.
+    :param resolution: Time-block resolution used to detect concurrent events.
+        Default 5 minutes.
+
+    :raises RuntimeError: If an Area or Station has zero peak concurrency but
+        the database still holds matching events — this indicates an
+        inconsistency and is never silently ignored.
+    """
+    with create_session(scenario, database_url) as (session, scenario):
+        _shrink_areas_to_peak(scenario, session, resolution)
+        _shrink_stations_to_peak(scenario, session, resolution)
+
+
 def simulate_scenario(
     scenario: Union[Scenario, int, Any],
     repetition_period: Optional[timedelta] = None,
@@ -639,6 +683,8 @@ def simulate_scenario(
     smart_charging_strategy: SmartChargingStrategy = SmartChargingStrategy.NONE,
     ignore_unstable_simulation: bool = False,
     ignore_delayed_trips: bool = False,
+    shrink_to_peak_usage: bool = True,
+    shrink_resolution: timedelta = timedelta(minutes=5),
 ) -> None:
     """
     This method simulates a scenario and adds the results to the database.
@@ -673,6 +719,14 @@ def simulate_scenario(
 
     :param ignore_unstable_simulation: If True, the simulation will not raise an exception if it becomes unstable.
     :param ignore_delayed_trips: If True, the simulation will not raise an exception if there are delayed trips.
+
+    :param shrink_to_peak_usage: If True (the default), Areas and electrified
+        opportunity-charging Stations are shrunk to their peak observed usage
+        after the events have been written to the database. See
+        :func:`shrink_to_peak_usage` for details.
+
+    :param shrink_resolution: Time-block resolution used when computing peak
+        concurrency for the shrinking step. Default 5 minutes.
 
     :return: Nothing. The results are added to the database.
 
@@ -713,6 +767,10 @@ def simulate_scenario(
         # Only the DelayedTripException will be raised if both exceptions are in the list.
         for e in errors:
             raise e
+
+        if shrink_to_peak_usage:
+            _shrink_areas_to_peak(scenario, session, shrink_resolution)
+            _shrink_stations_to_peak(scenario, session, shrink_resolution)
 
         match smart_charging_strategy:
             case SmartChargingStrategy.NONE:

--- a/eflips/depot/api/private/shrink.py
+++ b/eflips/depot/api/private/shrink.py
@@ -1,0 +1,182 @@
+"""Shrink Areas and electrified terminus Stations to peak observed concurrency.
+
+Internal helpers for :func:`eflips.depot.api.shrink_to_peak_usage`. Operates on
+events already persisted to the database (run after
+:func:`eflips.depot.api.add_evaluation_to_database`).
+"""
+
+import math
+from datetime import timedelta
+from typing import Iterable, List
+
+import numpy as np
+from eflips.model import (
+    Area,
+    AreaType,
+    AssocAreaProcess,
+    ChargeType,
+    Event,
+    EventType,
+    Scenario,
+    Station,
+)
+from sqlalchemy.orm import Session
+
+
+def _compute_peak_concurrency(events: Iterable[Event], resolution: timedelta) -> int:
+    """Count the maximum number of simultaneously-active events.
+
+    Each event occupies time blocks ``[floor(start/res), max(start+1, ceil(end/res)))``
+    relative to the earliest start. Back-to-back events at a block boundary do not
+    overlap; sub-resolution events still count as one block.
+    """
+    events_list: List[Event] = list(events)
+    if not events_list:
+        return 0
+
+    res_s = resolution.total_seconds()
+    if res_s <= 0:
+        raise ValueError("resolution must be a positive timedelta")
+
+    t_min = min(e.time_start for e in events_list)
+    t_max = max(e.time_end for e in events_list)
+    span_s = (t_max - t_min).total_seconds()
+    n_blocks = max(1, math.ceil(span_s / res_s))
+    arr = np.zeros(n_blocks, dtype=np.int64)
+
+    for e in events_list:
+        start_offset = (e.time_start - t_min).total_seconds()
+        end_offset = (e.time_end - t_min).total_seconds()
+        s = int(start_offset // res_s)
+        f = int(math.ceil(end_offset / res_s))
+        if f <= s:
+            f = s + 1
+        arr[s:f] += 1
+
+    return int(arr.max())
+
+
+def _round_capacity_for_area_type(peak: int, area: Area) -> int:
+    """Round ``peak`` UP to the next valid capacity for ``area.area_type``.
+
+    Preserves the CHECK constraint defined on :class:`eflips.model.Area`:
+
+    - DIRECT_ONESIDE: any positive int
+    - DIRECT_TWOSIDE: capacity must be even
+    - LINE: capacity must be a multiple of ``row_count`` (which is preserved)
+    """
+    if peak <= 0:
+        raise ValueError("peak must be > 0 for capacity rounding")
+
+    if area.area_type == AreaType.DIRECT_ONESIDE:
+        return peak
+    if area.area_type == AreaType.DIRECT_TWOSIDE:
+        return peak + (peak % 2)
+    if area.area_type == AreaType.LINE:
+        if area.row_count is None or area.row_count <= 0:
+            raise ValueError(
+                f"LINE area {area.id} has invalid row_count={area.row_count}"
+            )
+        return math.ceil(peak / area.row_count) * area.row_count
+    raise ValueError(f"Unknown area_type {area.area_type!r} on area {area.id}")
+
+
+def _shrink_areas_to_peak(
+    scenario: Scenario, session: Session, resolution: timedelta
+) -> None:
+    """Shrink every :class:`Area` in ``scenario`` to its peak observed usage.
+
+    Areas whose peak concurrency is zero are deleted along with their
+    :class:`AssocAreaProcess` rows. If we somehow compute a zero peak while
+    events still reference the area we raise :class:`RuntimeError` rather than
+    silently delete persisted state.
+    """
+    areas = session.query(Area).filter(Area.scenario_id == scenario.id).all()
+    area_ids_to_delete: List[int] = []
+
+    for area in areas:
+        peak = _compute_peak_concurrency(area.events, resolution)
+
+        if peak > 0:
+            area.capacity = _round_capacity_for_area_type(peak, area)
+            continue
+
+        lingering = session.query(Event).filter(Event.area_id == area.id).count()
+        if lingering > 0:
+            raise RuntimeError(
+                f"Area {area.id} has peak concurrency 0 but {lingering} "
+                "lingering events: refusing to delete."
+            )
+
+        area_ids_to_delete.append(area.id)
+
+    if area_ids_to_delete:
+        # Detach soon-to-be-deleted areas from the ORM so cascades on
+        # AssocAreaProcess do not fight the bulk delete below.
+        for area in areas:
+            if area.id in area_ids_to_delete:
+                session.expunge(area)
+
+        session.query(AssocAreaProcess).filter(
+            AssocAreaProcess.area_id.in_(area_ids_to_delete)
+        ).delete(synchronize_session=False)
+        session.query(Area).filter(Area.id.in_(area_ids_to_delete)).delete(
+            synchronize_session=False
+        )
+
+    session.flush()
+
+
+def _shrink_stations_to_peak(
+    scenario: Scenario, session: Session, resolution: timedelta
+) -> None:
+    """Shrink electrified opportunity-charging Stations to peak observed usage.
+
+    Only Stations with ``is_electrified=True`` and
+    ``charge_type=ChargeType.OPPORTUNITY`` are considered. If peak > 0 we update
+    ``amount_charging_places`` and recompute ``power_total``. If peak == 0 we
+    un-electrify the station, atomically nulling all electrification fields to
+    keep the CHECK constraint satisfied.
+    """
+    stations = (
+        session.query(Station)
+        .filter(Station.scenario_id == scenario.id)
+        .filter(Station.is_electrified.is_(True))
+        .filter(Station.charge_type == ChargeType.OPPORTUNITY)
+        .all()
+    )
+
+    for station in stations:
+        events = (
+            session.query(Event)
+            .filter(Event.station_id == station.id)
+            .filter(Event.event_type == EventType.CHARGING_OPPORTUNITY)
+            .all()
+        )
+        peak = _compute_peak_concurrency(events, resolution)
+
+        if peak > 0:
+            station.amount_charging_places = peak
+            if station.power_per_charger is not None:
+                station.power_total = peak * station.power_per_charger
+            continue
+
+        lingering = (
+            session.query(Event)
+            .filter(Event.station_id == station.id)
+            .filter(Event.event_type == EventType.CHARGING_OPPORTUNITY)
+            .count()
+        )
+        if lingering > 0:
+            raise RuntimeError(
+                f"Station {station.id} has peak concurrency 0 but {lingering} "
+                "CHARGING_OPPORTUNITY events: refusing to un-electrify."
+            )
+
+        station.is_electrified = False
+        station.amount_charging_places = None
+        station.power_per_charger = None
+        station.power_total = None
+        station.charge_type = None
+        station.voltage_level = None
+        session.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-depot"
-version = "4.17.2"
+version = "4.18.0"
 description = "Depot Simulation for eFLIPS"
 authors = ["Enrico Lauth <enrico.lauth@tu-berlin.de>",
     "Ludger Heide <ludger.heide@tu-berlin.de",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -44,6 +44,7 @@ from eflips.depot.api import (
     schedule_duration_days,
     create_diesel_vehicle_type_copies,
     delete_depots,
+    shrink_to_peak_usage,
 )
 
 
@@ -1434,6 +1435,100 @@ class TestApi(TestHelpers):
         assert len(diesel_events) > 0
         assert all(e.soc_start == 1.0 for e in diesel_events)
         assert all(e.soc_end == 1.0 for e in diesel_events)
+
+
+class TestShrinkToPeakUsage(TestHelpers):
+    def _peak_concurrency(self, events, resolution=timedelta(minutes=5)):
+        from eflips.depot.api.private.shrink import _compute_peak_concurrency
+
+        return _compute_peak_concurrency(events, resolution)
+
+    def _run_manual_flow(self, session, scenario):
+        generate_depot_layout(
+            scenario=scenario, charging_power=90, delete_existing_depot=True
+        )
+        simulation_host = init_simulation(scenario, session)
+        depot_evaluations = run_simulation(simulation_host)
+        add_evaluation_to_database(scenario, depot_evaluations, session)
+        session.flush()
+
+    def test_shrink_after_manual_flow(self, session, full_scenario):
+        self._run_manual_flow(session, full_scenario)
+
+        pre_areas = (
+            session.query(Area).filter(Area.scenario_id == full_scenario.id).all()
+        )
+        assert len(pre_areas) > 0
+        pre_capacities = {a.id: a.capacity for a in pre_areas}
+
+        shrink_to_peak_usage(scenario=full_scenario)
+        session.expire_all()
+
+        post_areas = (
+            session.query(Area).filter(Area.scenario_id == full_scenario.id).all()
+        )
+
+        # Some Areas got shrunk or deleted
+        assert len(post_areas) <= len(pre_areas)
+        shrunk_or_deleted = len(pre_areas) - len(post_areas)
+        for area in post_areas:
+            if area.id in pre_capacities and area.capacity < pre_capacities[area.id]:
+                shrunk_or_deleted += 1
+        assert shrunk_or_deleted > 0
+
+        # Every remaining Area has capacity matching its rounded peak
+        from eflips.depot.api.private.shrink import _round_capacity_for_area_type
+
+        for area in post_areas:
+            events = session.query(Event).filter(Event.area_id == area.id).all()
+            peak = self._peak_concurrency(events)
+            assert peak > 0, f"Area {area.id} survived shrink with no events"
+            assert area.capacity == _round_capacity_for_area_type(peak, area)
+
+    def test_shrink_via_simulate_scenario_default(self, session, full_scenario):
+        # Default path: simulate_scenario(shrink_to_peak_usage=True) is the default.
+        generate_depot_layout(
+            scenario=full_scenario, charging_power=90, delete_existing_depot=True
+        )
+        simulate_scenario(scenario=full_scenario)
+        session.expire_all()
+
+        from eflips.depot.api.private.shrink import _round_capacity_for_area_type
+
+        post_areas = (
+            session.query(Area).filter(Area.scenario_id == full_scenario.id).all()
+        )
+        assert len(post_areas) > 0
+        for area in post_areas:
+            events = session.query(Event).filter(Event.area_id == area.id).all()
+            peak = self._peak_concurrency(events)
+            assert peak > 0
+            assert area.capacity == _round_capacity_for_area_type(peak, area)
+
+    def test_shrink_disabled_runs_without_error(self, session, full_scenario):
+        # The boolean opt-out is wired correctly: simulate_scenario completes
+        # and leaves some areas in place when shrinking is disabled.
+        generate_depot_layout(
+            scenario=full_scenario, charging_power=90, delete_existing_depot=True
+        )
+        simulate_scenario(scenario=full_scenario, shrink_to_peak_usage=False)
+        session.expire_all()
+        areas = session.query(Area).filter(Area.scenario_id == full_scenario.id).all()
+        assert len(areas) > 0
+
+    def test_defensive_runtime_error_when_zero_peak_with_events(
+        self, session, full_scenario, monkeypatch
+    ):
+        self._run_manual_flow(session, full_scenario)
+
+        # An Area with events exists; force peak=0 to trigger the defensive raise.
+        from eflips.depot.api.private import shrink as shrink_mod
+
+        monkeypatch.setattr(shrink_mod, "_compute_peak_concurrency", lambda *a, **kw: 0)
+        session.commit()
+
+        with pytest.raises(RuntimeError):
+            shrink_to_peak_usage(scenario=full_scenario)
 
 
 class TestSimpleConsumptionSimulation(TestHelpers):

--- a/tests/api/test_api_private.py
+++ b/tests/api/test_api_private.py
@@ -1,12 +1,17 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 import simpy
-from eflips.model import Event, EventType, Rotation, Vehicle, VehicleType
+from eflips.model import AreaType, Event, EventType, Rotation, Vehicle, VehicleType
 
 from tests.api.test_api import TestHelpers
 from eflips.depot import Depotinput, SimpleTrip, SimulationHost
 from eflips.depot.api.private.depot import depot_to_template
+from eflips.depot.api.private.shrink import (
+    _compute_peak_concurrency,
+    _round_capacity_for_area_type,
+)
 from eflips.depot.api.private.util import (
     vehicle_type_to_global_constants_dict,
     VehicleSchedule,
@@ -209,3 +214,74 @@ class TestDepot(TestHelpers):
         with pytest.raises(AssertionError):
             check_depot_validity(depot)
         session.rollback()
+
+
+def _ev(start_minutes: float, end_minutes: float) -> SimpleNamespace:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        time_start=base + timedelta(minutes=start_minutes),
+        time_end=base + timedelta(minutes=end_minutes),
+    )
+
+
+class TestComputePeakConcurrency:
+    res = timedelta(minutes=5)
+
+    def test_empty(self):
+        assert _compute_peak_concurrency([], self.res) == 0
+
+    def test_two_non_overlapping(self):
+        events = [_ev(0, 10), _ev(20, 30)]
+        assert _compute_peak_concurrency(events, self.res) == 1
+
+    def test_two_overlapping(self):
+        events = [_ev(0, 30), _ev(10, 20)]
+        assert _compute_peak_concurrency(events, self.res) == 2
+
+    def test_three_two_overlap_one_alone(self):
+        events = [_ev(0, 20), _ev(10, 30), _ev(60, 70)]
+        assert _compute_peak_concurrency(events, self.res) == 2
+
+    def test_back_to_back_at_resolution_boundary(self):
+        events = [_ev(0, 5), _ev(5, 10)]
+        assert _compute_peak_concurrency(events, self.res) == 1
+
+    def test_sub_resolution_event(self):
+        events = [_ev(0, 1)]
+        assert _compute_peak_concurrency(events, self.res) == 1
+
+    def test_invalid_resolution(self):
+        with pytest.raises(ValueError):
+            _compute_peak_concurrency([_ev(0, 5)], timedelta(seconds=0))
+
+
+class TestRoundCapacityForAreaType:
+    def test_oneside(self):
+        area = SimpleNamespace(id=1, area_type=AreaType.DIRECT_ONESIDE, row_count=None)
+        assert _round_capacity_for_area_type(5, area) == 5
+
+    def test_twoside_odd(self):
+        area = SimpleNamespace(id=2, area_type=AreaType.DIRECT_TWOSIDE, row_count=None)
+        assert _round_capacity_for_area_type(3, area) == 4
+
+    def test_twoside_even(self):
+        area = SimpleNamespace(id=3, area_type=AreaType.DIRECT_TWOSIDE, row_count=None)
+        assert _round_capacity_for_area_type(4, area) == 4
+
+    def test_line_rounds_up(self):
+        area = SimpleNamespace(id=4, area_type=AreaType.LINE, row_count=4)
+        assert _round_capacity_for_area_type(5, area) == 8
+
+    def test_line_exact(self):
+        area = SimpleNamespace(id=5, area_type=AreaType.LINE, row_count=4)
+        assert _round_capacity_for_area_type(4, area) == 4
+
+    def test_line_missing_row_count(self):
+        area = SimpleNamespace(id=6, area_type=AreaType.LINE, row_count=None)
+        with pytest.raises(ValueError):
+            _round_capacity_for_area_type(5, area)
+
+    def test_zero_peak_rejected(self):
+        area = SimpleNamespace(id=7, area_type=AreaType.DIRECT_ONESIDE, row_count=None)
+        with pytest.raises(ValueError):
+            _round_capacity_for_area_type(0, area)


### PR DESCRIPTION
## Summary

- Auto-generated depots are intentionally over-provisioned, which inflates downstream cost estimation. After simulation events are persisted, this PR walks every `Area` and every `is_electrified` opportunity-charging `Station` for the scenario and reduces `Area.capacity` / `Station.amount_charging_places` to the peak number of simultaneous events observed (5-minute resolution by default, area-type rounding rules respected).
- Areas with zero peak are deleted; `oppb` stations with zero `CHARGING_OPPORTUNITY` events are atomically un-electrified. If a zero peak is computed while events still reference the entity, the operation aborts with `RuntimeError` instead of silently dropping persisted state.
- Exposed as `shrink_to_peak_usage(scenario, ...)` in the public API and wired into `simulate_scenario` behind a default-`True` `shrink_to_peak_usage` parameter (with a `shrink_resolution` knob).

## Test plan

- [x] Unit tests in `tests/api/test_api_private.py` cover `_compute_peak_concurrency` (empty, overlap, back-to-back at boundary, sub-resolution) and `_round_capacity_for_area_type` (ONESIDE / TWOSIDE / LINE rounding plus invalid inputs)
- [x] Integration tests in `tests/api/test_api.py` cover the manual flow, the `simulate_scenario` default path, the `shrink_to_peak_usage=False` opt-out, and the defensive `RuntimeError` contract
- [x] `poetry run pytest tests/api/` — 75 passed
- [x] `poetry run black ...` — clean
- [x] `mypy --strict` on the new private module — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)