### PR TITLE
Fix zero-consumption segments on circular routes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "eFLIPS-Depot"
 copyright = "2023, MPM TU Berlin"
 author = "MPM TU Berlin"
-release = "4.18.1"
+release = "4.18.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/eflips/depot/api/private/consumption.py
+++ b/eflips/depot/api/private/consumption.py
@@ -1,9 +1,10 @@
 import logging
 import warnings
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta, datetime
 from math import ceil
-from typing import TYPE_CHECKING, Any, Dict, Tuple, List, Optional
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Tuple, List, Optional
 
 if TYPE_CHECKING:
     import scipy.interpolate
@@ -559,28 +560,57 @@ def _build_trip_segments(
     constant across all segments — sample it once at the trip midpoint upstream.
     """
     route = trip.route
-    assoc_by_station: Dict[int, AssocRouteStation] = {
-        a.station_id: a for a in route.assoc_route_stations
-    }
+    # On circular routes (e.g. ZOB → … → ZOB) the same station appears more
+    # than once in ``assoc_route_stations`` at different elapsed_distances.
+    # Keep every occurrence so we can pick the right one per StopTime; a flat
+    # ``station_id -> AssocRouteStation`` dict would collapse duplicates to
+    # the last occurrence and assign return-leg distances to early stops,
+    # producing zero-distance/zero-consumption segments at the trip start.
+    assocs_by_station: DefaultDict[int, List[AssocRouteStation]] = defaultdict(list)
+    for a in route.assoc_route_stations:
+        assocs_by_station[a.station_id].append(a)
+
+    trip_duration_s = (trip.arrival_time - trip.departure_time).total_seconds()
+    route_distance_m = float(route.distance)
+
+    def _pick_assoc(
+        candidates: List[AssocRouteStation], stop_time: datetime
+    ) -> AssocRouteStation:
+        """Choose the occurrence whose elapsed_distance best matches the
+        time-fraction of ``stop_time`` along the trip. Falls back to the first
+        candidate when the trip has zero duration."""
+        if len(candidates) == 1 or trip_duration_s <= 0:
+            return candidates[0]
+        t_s = (stop_time - trip.departure_time).total_seconds()
+        expected_m = (t_s / trip_duration_s) * route_distance_m
+        return min(
+            candidates, key=lambda a: abs(float(a.elapsed_distance) - expected_m)
+        )
 
     # 1. Build the stop-time-derived knot list as (elapsed_distance_m, time, z).
     stop_times = sorted(trip.stop_times, key=lambda st: st.arrival_time)
     knots: List[Tuple[float, datetime, Optional[float]]] = []
     if stop_times:
         for st in stop_times:
-            assoc = assoc_by_station.get(st.station_id)
-            if assoc is None:
+            candidates = assocs_by_station.get(st.station_id)
+            if not candidates:
                 raise ValueError(
                     f"StopTime {st.id} references station {st.station_id} which is "
                     f"not in route {route.id}'s assoc_route_stations."
                 )
+            assoc = _pick_assoc(candidates, st.arrival_time)
             z = _assoc_z(assoc)
             if z is None:
                 z = _station_z(st.station)
             knots.append((float(assoc.elapsed_distance), st.arrival_time, z))
     else:
-        dep_assoc = assoc_by_station.get(route.departure_station_id)
-        arr_assoc = assoc_by_station.get(route.arrival_station_id)
+        # On a circular route departure_station_id == arrival_station_id; take
+        # the first occurrence as departure (elapsed_distance == 0) and the
+        # last as arrival (elapsed_distance == route.distance).
+        dep_candidates = assocs_by_station.get(route.departure_station_id, [])
+        arr_candidates = assocs_by_station.get(route.arrival_station_id, [])
+        dep_assoc = dep_candidates[0] if dep_candidates else None
+        arr_assoc = arr_candidates[-1] if arr_candidates else None
         dep_z = _assoc_z(dep_assoc) if dep_assoc else None
         if dep_z is None:
             dep_z = _station_z(route.departure_station)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-depot"
-version = "4.18.1"
+version = "4.18.2"
 description = "Depot Simulation for eFLIPS"
 authors = ["Enrico Lauth <enrico.lauth@tu-berlin.de>",
     "Ludger Heide <ludger.heide@tu-berlin.de",

--- a/tests/api/private/test_consumption.py
+++ b/tests/api/private/test_consumption.py
@@ -1035,3 +1035,145 @@ class TestConsumptionInformation(TestHelpers):
         ]
         assert len(z_warnings) == 1
         assert all(s.incline == 0.0 for s in info.segments)
+
+    def test_extract_trip_information_circular_route(self, session, scenario):
+        """Circular routes (A → B → C → B → A) revisit stations.
+
+        Regression test for the bug where ``_build_trip_segments`` collapsed
+        every occurrence of a station_id to the last AssocRouteStation,
+        causing the first one or two segments to receive ``distance_m = 0``
+        and ``consumption_kwh = 0``. Every segment should carry the real
+        distance between its endpoints.
+        """
+        # 3 distinct stations; A and B each appear twice in the route.
+        station_a = Station(
+            scenario=scenario,
+            name="Circular A",
+            name_short="CA",
+            geom=from_shape(Point(0, 0, 0), srid=4326),
+            is_electrified=False,
+        )
+        station_b = Station(
+            scenario=scenario,
+            name="Circular B",
+            name_short="CB",
+            geom=from_shape(Point(1, 0, 0), srid=4326),
+            is_electrified=False,
+        )
+        station_c = Station(
+            scenario=scenario,
+            name="Circular C",
+            name_short="CC",
+            geom=from_shape(Point(2, 0, 0), srid=4326),
+            is_electrified=False,
+        )
+        session.add_all([station_a, station_b, station_c])
+
+        vehicle_type = VehicleType(
+            scenario=scenario,
+            name="Circular Bus",
+            battery_capacity=100,
+            charging_curve=[[0, 150], [1, 150]],
+            allowed_mass=18000,
+            empty_mass=12000,
+            consumption=1.5,
+            opportunity_charging_capable=False,
+        )
+        session.add(vehicle_type)
+        vehicle_class = VehicleClass(
+            scenario=scenario,
+            name="Circular Vehicle Class",
+            vehicle_types=[vehicle_type],
+            consumption_lut=None,
+        )
+        session.add(vehicle_class)
+
+        line = Line(scenario=scenario, name="Circular Line", name_short="CL")
+        session.add(line)
+
+        # 20 km round trip: A(0) -> B(5) -> C(10) -> B(15) -> A(20).
+        route = Route(
+            scenario=scenario,
+            name="Circular Route",
+            name_short="CR",
+            departure_station=station_a,
+            arrival_station=station_a,
+            line=line,
+            distance=20_000,
+        )
+        route.assoc_route_stations = [
+            AssocRouteStation(
+                scenario=scenario, station=station_a, route=route, elapsed_distance=0
+            ),
+            AssocRouteStation(
+                scenario=scenario,
+                station=station_b,
+                route=route,
+                elapsed_distance=5_000,
+            ),
+            AssocRouteStation(
+                scenario=scenario,
+                station=station_c,
+                route=route,
+                elapsed_distance=10_000,
+            ),
+            AssocRouteStation(
+                scenario=scenario,
+                station=station_b,
+                route=route,
+                elapsed_distance=15_000,
+            ),
+            AssocRouteStation(
+                scenario=scenario,
+                station=station_a,
+                route=route,
+                elapsed_distance=20_000,
+            ),
+        ]
+        session.add(route)
+
+        rotation = Rotation(
+            scenario=scenario,
+            vehicle_type=vehicle_type,
+            allow_opportunity_charging=False,
+        )
+        session.add(rotation)
+
+        # 60-minute trip with one stop every 15 minutes.
+        t0 = datetime(2020, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+        trip = Trip(
+            scenario=scenario,
+            route=route,
+            rotation=rotation,
+            trip_type=TripType.PASSENGER,
+            departure_time=t0,
+            arrival_time=t0 + timedelta(minutes=60),
+        )
+        session.add(trip)
+        for i, station in enumerate(
+            [station_a, station_b, station_c, station_b, station_a]
+        ):
+            session.add(
+                StopTime(
+                    scenario=scenario,
+                    station=station,
+                    trip=trip,
+                    arrival_time=t0 + timedelta(minutes=15 * i),
+                    dwell_duration=timedelta(seconds=0),
+                )
+            )
+        session.flush()
+
+        with pytest.warns(ConsistencyWarning, match="No consumption LUT found"):
+            info = extract_trip_information(trip.id, scenario)
+
+        assert len(info.segments) == 4
+        # Every segment should be a real 5 km leg with nonzero consumption,
+        # not silently clamped to 0 by the dict-comprehension bug.
+        for seg in info.segments:
+            assert seg.distance_m == pytest.approx(5_000.0)
+            assert seg.consumption_kwh == pytest.approx(1.5 * 5.0)
+        assert sum(s.distance_m for s in info.segments) == pytest.approx(20_000.0)
+        assert sum(s.consumption_kwh for s in info.segments) == pytest.approx(
+            1.5 * 20.0
+        )


### PR DESCRIPTION
## Summary

On a route that revisits the same station (e.g. a depot-to-depot loop like SWU line 11, ZOB → … → ZOB), `_build_trip_segments` built a `station_id -> AssocRouteStation` dict comprehension that silently collapsed duplicates to the last occurrence. The first `StopTime`(s) for the duplicated station(s) then looked up the *return-leg* `elapsed_distance`, producing decreasing knot distances; per-segment `distance = max(0, d_curr - d_prev)` clamped those to zero, the LUT call returned `kWh/km * 0 / 1000 = 0`, and the lost energy was silently dropped from `delta_soc_total`.

The fix replaces the dict with a per-station list of `AssocRouteStation`s and picks the occurrence whose `elapsed_distance` best matches the `StopTime`'s time-fraction along the trip (mirroring the heuristic already used by `TripProfileAnalyzer.analyze` in eflips-x).

- `eflips/depot/api/private/consumption.py` — fix `_build_trip_segments`, including the no-`stop_times` fallback which previously took the departure Z from the *last* AssocRouteStation on circular routes.
- `tests/api/private/test_consumption.py` — regression test on a synthetic A→B→C→B→A circular route: every 5 km leg now carries the correct distance and consumption.
- Version bump to 4.18.2.

## Test plan

- [x] `pytest tests/api/private/test_consumption.py` — 18 passed, including new `test_extract_trip_information_circular_route`
- [x] `pytest tests/api/` — 76 passed, no regressions
- [x] `black eflips/depot/api/private/consumption.py tests/api/private/test_consumption.py` — clean
- [x] `mypy --explicit-package-bases --ignore-missing-imports` on the touched file: changed lines introduce no new errors (8 pre-existing errors elsewhere in the file remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)